### PR TITLE
[Bugfix] Require test utils directly

### DIFF
--- a/lib/virtual-dom-utils.js
+++ b/lib/virtual-dom-utils.js
@@ -1,6 +1,6 @@
 (function(){
   var testUtils, extractRoute, formElements, routeMetadata, toString$ = {}.toString;
-  testUtils = React.addons.TestUtils;
+  testUtils = require('react/lib/ReactTestUtils');
   extractRoute = function(tree){
     var routes;
     routes = testUtils.findAllInRenderedTree(tree, function(it){

--- a/src/virtual-dom-utils.ls
+++ b/src/virtual-dom-utils.ls
@@ -1,4 +1,4 @@
-test-utils = React.addons.TestUtils
+test-utils = require 'react/lib/ReactTestUtils'
 
 extract-route = (tree) ->
   routes = test-utils.find-all-in-rendered-tree tree, ->


### PR DESCRIPTION
It isn't exported by react in production mode, so the server-side rendering fails in production without this.