### PR TITLE
Docs CI integration

### DIFF
--- a/build-docs.sh
+++ b/build-docs.sh
@@ -19,10 +19,9 @@ done
 
 rm temp
 
-echo $now
-echo "Doc updates $now"
-
 # Commit and push / submit pull request
 cd ../arch-js.github.io
+git config user.name "archbot"
+git config user.email "robbie.mccorkell+archbot@red-badger.com"
 git add .
 git commit -m "Doc updates $now"

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,4 +1,5 @@
 # Checkout website
+git clone git@github.com:arch-js/arch-js.github.io.git
 
 # Copy Docs
 

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,19 +1,28 @@
+now=$(date +"%Y-%m-%d")
+
 npm install -g tidy-markdown
 
 # Checkout website
-git clone git@github.com:arch-js/arch-js.github.io.git
+git clone git@github.com:arch-js/arch-js.github.io.git ../arch-js.github.io
 
-echo $PWD
-# Copy Docs
-# Run through beautifier
+# Copy docs to website
 for file in ./docs/*
 do
-  tidy-markdown < $file > ../arch-js.github.io/docs/$file.md
+  echo $(basename "$file")
+
+  # Run through prettifier
+  tidy-markdown < $file > temp
+
+  # Add frontmatter and copy to website
+  echo $'---\n\n---\n' | cat - temp > ../arch-js.github.io/docs/$(basename "$file")
 done
 
+rm temp
 
-# Add frontmatter
-
-# Copy to website
+echo $now
+echo "Doc updates $now"
 
 # Commit and push / submit pull request
+cd ../arch-js.github.io
+git add .
+git commit -m "Doc updates $now"

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,5 +1,5 @@
 # Checkout website
-# git clone git@github.com:arch-js/arch-js.github.io.git
+git clone git@github.com:arch-js/arch-js.github.io.git
 
 # Copy Docs
 

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,5 +1,5 @@
 # Checkout website
-git clone git@github.com:arch-js/arch-js.github.io.git
+# git clone git@github.com:arch-js/arch-js.github.io.git
 
 # Copy Docs
 

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,9 +1,16 @@
+npm install -g tidy-markdown
+
 # Checkout website
 git clone git@github.com:arch-js/arch-js.github.io.git
 
+echo $PWD
 # Copy Docs
-
 # Run through beautifier
+for file in ./docs/*
+do
+  tidy-markdown < $file > ../arch-js.github.io/docs/$file.md
+done
+
 
 # Add frontmatter
 

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,0 +1,11 @@
+# Checkout website
+
+# Copy Docs
+
+# Run through beautifier
+
+# Add frontmatter
+
+# Copy to website
+
+# Commit and push / submit pull request

--- a/circle-build-docs.sh
+++ b/circle-build-docs.sh
@@ -25,3 +25,4 @@ git config user.name "archbot"
 git config user.email "robbie.mccorkell+archbot@red-badger.com"
 git add .
 git commit -m "Doc updates $now"
+git push

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 deployment:
   master:
-    branch: master
+    branch: [master, build-docs]
     owner: arch-js
     commands:
       - ./build-docs.sh

--- a/circle.yml
+++ b/circle.yml
@@ -3,5 +3,4 @@ deployment:
     branch: [master, build-docs]
     owner: arch-js
     commands:
-      - git clone git@github.com:arch-js/arch-js.github.io.git
       - bash ./build-docs.sh

--- a/circle.yml
+++ b/circle.yml
@@ -3,4 +3,5 @@ deployment:
     branch: [master, build-docs]
     owner: arch-js
     commands:
+      - git clone git@github.com:arch-js/arch-js.github.io.git
       - ./build-docs.sh

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 deployment:
   master:
-    branch: [master, build-docs]
+    branch: master
     owner: arch-js
     commands:
       - bash ./build-docs.sh

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,6 @@
+deployment:
+  master:
+    branch: master
+    owner: arch-js
+    commands:
+      - ./build-docs.sh

--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,4 @@ deployment:
     owner: arch-js
     commands:
       - git clone git@github.com:arch-js/arch-js.github.io.git
-      - ./build-docs.sh
+      - bash ./build-docs.sh


### PR DESCRIPTION
I've tested this in CircleCI as far as I can without actually allowing it to push changes. CI is always tricky to test, any suggestions welcome!

On a successful test run in CircleCI, this script will:
- Clone the arch-js.github.io repo
- Run docs through a markdown prettifier
- Add empty Jekyll frontmatter to the top of each file. This is required for jekyll to render static files into HTML.
- Copy docs to arch-js.github.io
- Create a commit
- Push to master

Circle can not on its own checkout repositories outside of the one it is working in, even in the same organisation. In order to give circle further access rights I have creates a [machine user](https://developer.github.com/guides/managing-deploy-keys/) called [archbot](https://github.com/archbot). Archbot has read/write access to all repositories within the arch organisation. He is very excited about his new duties so please welcome him to the team.

For now this will just push to master in the repo, but perhaps it should make a branch and submit a pull request. However it would mean we would end up end up merging all doc changes twice.

What do you guys think?

![](http://i.imgur.com/HSVR6vX.gif)