### PR TITLE
Fix cross origin issue with hot loading

### DIFF
--- a/src/bundler.ls
+++ b/src/bundler.ls
@@ -85,6 +85,8 @@ exports.bundle = (paths, watch, changed) ->
       quiet: true
       no-info: false
       watch-delay: 200
+      headers: 
+        'Access-Control-Allow-Origin': '*'
 
     server.listen 3001, 'localhost'
 


### PR DESCRIPTION
Fixes #76 with the solution [described here](https://github.com/gaearon/react-hot-loader/blob/master/docs/Troubleshooting.md#no-access-control-allow-origin-header-is-present-on-the-requested-resource).