### PR TITLE
Add source-map devtool to webpack config

### DIFF
--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -46,7 +46,8 @@
         ],
         loaders: [],
         postLoaders: []
-      }
+      },
+      devtool: 'source-map'
     };
     if (process.env.NODE_ENV === 'production') {
       config.plugins.push(new webpack.optimize.DedupePlugin());

--- a/src/bundler.ls
+++ b/src/bundler.ls
@@ -44,6 +44,8 @@ exports.bundle = (paths, watch, changed) ->
       loaders: []
       post-loaders: []
 
+    devtool: \source-map
+
   # Optimise for production.
   if process.env.NODE_ENV is 'production'
     config.plugins.push new webpack.optimize.DedupePlugin!
@@ -85,7 +87,7 @@ exports.bundle = (paths, watch, changed) ->
       quiet: true
       no-info: false
       watch-delay: 200
-      headers: 
+      headers:
         'Access-Control-Allow-Origin': '*'
 
     server.listen 3001, 'localhost'


### PR DESCRIPTION
This enables source maps, so that even when I'm debugging, I don't have to look at vanilla JS. :smiley: 