### PR TITLE
Lowercase LiveScript require in specs

### DIFF
--- a/spec/helpers/spec_helper.js
+++ b/spec/helpers/spec_helper.js
@@ -1,1 +1,1 @@
-require('LiveScript');
+require('livescript');


### PR DESCRIPTION
Lowercase this leftover TitleCased version `livescript`, a la https://github.com/arch-js/arch/commit/b5b0aa88ce398009b2240cb80fdb31e64735b7d3