### PR TITLE
Add has-listener to cursor

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -165,9 +165,6 @@
     this._root._transactions.push(t);
     return t;
   };
-  Cursor.prototype.hasListener = function(){
-    return this.listeners().length > 0;
-  };
   Cursor.prototype.listeners = function(){
     var key;
     key = join('.', this._path);

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -165,6 +165,11 @@
     this._root._transactions.push(t);
     return t;
   };
+  Cursor.prototype.hasListener = function(){
+    var key;
+    key = join('.', this._path);
+    return this._root._listeners[key] instanceof Array && this._root._listeners[key].length > 0;
+  };
   Cursor.prototype.isEmpty = function(){
     var data;
     data = this._root._data.getIn(this._path);

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -166,9 +166,16 @@
     return t;
   };
   Cursor.prototype.hasListener = function(){
+    return this.listeners().length > 0;
+  };
+  Cursor.prototype.listeners = function(){
     var key;
     key = join('.', this._path);
-    return this._root._listeners[key] instanceof Array && this._root._listeners[key].length > 0;
+    if (this._root._listeners[key] instanceof Array) {
+      return this._root._listeners[key].slice();
+    } else {
+      return [];
+    }
   };
   Cursor.prototype.isEmpty = function(){
     var data;

--- a/spec/cursor_spec.ls
+++ b/spec/cursor_spec.ls
@@ -312,19 +312,6 @@ describe "cursor" (_) ->
       expect(data.listeners! instanceof Array) .to-equal true
       expect(data.listeners!.length) .to-equal 0
 
-  describe "has-listener", (_) ->
-    it "returns true if the cursor has a listener at its current path" ->
-      data = cursor raw-data
-      data
-        .get 'person'
-        .on-change -> null
-
-      expect(data.get('person').has-listener!) .to-equal true
-
-    it "returns false if the cursor has no listener at its current path" ->
-      data = cursor raw-data
-      expect(data.has-listener!) .to-equal false
-
   describe "is-empty", (_) ->
     it "returns true if data is null" ->
       data = cursor raw-data

--- a/spec/cursor_spec.ls
+++ b/spec/cursor_spec.ls
@@ -298,6 +298,20 @@ describe "cursor" (_) ->
 
       expect log .to-equal ["first", "second"]
 
+  describe "listeners", (_) ->
+    it "returns an array of listeners at the cursor's current path" ->
+      data = cursor raw-data
+      fn = -> null
+      data.on-change fn
+
+      expect(data.listeners()[0]) .to-equal fn
+
+    it "returns an empty array when no listeners are present" ->
+      data = cursor raw-data
+
+      expect(data.listeners! instanceof Array) .to-equal true
+      expect(data.listeners!.length) .to-equal 0
+
   describe "has-listener", (_) ->
     it "returns true if the cursor has a listener at its current path" ->
       data = cursor raw-data

--- a/spec/cursor_spec.ls
+++ b/spec/cursor_spec.ls
@@ -298,6 +298,19 @@ describe "cursor" (_) ->
 
       expect log .to-equal ["first", "second"]
 
+  describe "has-listener", (_) ->
+    it "returns true if the cursor has a listener at its current path" ->
+      data = cursor raw-data
+      data
+        .get 'person'
+        .on-change -> null
+
+      expect(data.get('person').has-listener!) .to-equal true
+
+    it "returns false if the cursor has no listener at its current path" ->
+      data = cursor raw-data
+      expect(data.has-listener!) .to-equal false
+
   describe "is-empty", (_) ->
     it "returns true if data is null" ->
       data = cursor raw-data

--- a/src/cursor.ls
+++ b/src/cursor.ls
@@ -129,6 +129,10 @@ Cursor.prototype.start-transaction = ->
   @_root._transactions.push t
   return t
 
+Cursor.prototype.has-listener = ->
+  key = join '.', @_path
+  @_root._listeners[key] instanceof Array && @_root._listeners[key].length > 0
+
 Cursor.prototype.is-empty = ->
   data = @_root._data.get-in @_path
   typeof data is 'undefined' or data is null

--- a/src/cursor.ls
+++ b/src/cursor.ls
@@ -130,8 +130,11 @@ Cursor.prototype.start-transaction = ->
   return t
 
 Cursor.prototype.has-listener = ->
+  @listeners!.length > 0
+
+Cursor.prototype.listeners = ->
   key = join '.', @_path
-  @_root._listeners[key] instanceof Array && @_root._listeners[key].length > 0
+  if @_root._listeners[key] instanceof Array then @_root._listeners[key].slice! else []
 
 Cursor.prototype.is-empty = ->
   data = @_root._data.get-in @_path

--- a/src/cursor.ls
+++ b/src/cursor.ls
@@ -129,9 +129,6 @@ Cursor.prototype.start-transaction = ->
   @_root._transactions.push t
   return t
 
-Cursor.prototype.has-listener = ->
-  @listeners!.length > 0
-
 Cursor.prototype.listeners = ->
   key = join '.', @_path
   if @_root._listeners[key] instanceof Array then @_root._listeners[key].slice! else []


### PR DESCRIPTION
Quick method to check if a cursor already has a listener at its current path.

Useful for dynamically generated cursor paths.